### PR TITLE
Added dependency configuration named "gretty" for adding dependencies to the Jetty classpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ All versions of gretty are available at jcenter and maven central under the grou
 * [Logging](#logging)
 * [jetty.xml support](#jettyxml-support)
 * [jetty-env.xml support](#jetty-envxml-support)
+* [Jetty Classpath](#jetty-classpath)
 * [JEE annotations support](#jee-annotations-support)
 * [Web fragments support](#web-fragments-support)
 * [Integration tests support](#integration-tests-support)
@@ -686,6 +687,20 @@ to find corresponding existing file in the following directories:
 Gretty sources contain example program demonstrating integration of "jetty-env.xml" at work:
 
 - [examples/testJettyEnvXml](https://github.com/akhikhl/gretty/tree/master/examples/testJettyEnvXml)
+
+## Jetty Classpath
+
+Gretty supports the ability to add dependencies to the Jetty classpath. 
+This can be used to add libraries, such as JDBC drivers, which may be needed when Jetty is starting up.
+You can add your dependencies using the `gretty` configuration:
+
+```groovy
+dependencies {
+  // ...
+  gretty 'org.hsqldb:hsqldb:+'
+  // ...
+}
+```
 
 ## JEE annotations support
 

--- a/libs/gretty-plugin-commons/src/main/groovy/org/akhikhl/gretty/GrettyPluginBase.groovy
+++ b/libs/gretty-plugin-commons/src/main/groovy/org/akhikhl/gretty/GrettyPluginBase.groovy
@@ -28,6 +28,7 @@ abstract class GrettyPluginBase implements Plugin<Project> {
     project.configurations {
       grettyHelperConfig
       grettyLoggingConfig
+	  gretty.extendsFrom(grettyHelperConfig)
     }
 
     injectDependencies(project)
@@ -153,7 +154,7 @@ abstract class GrettyPluginBase implements Plugin<Project> {
         scanman.startScanner(project, options.inplace)
         try {
           project.javaexec {
-            classpath = project.configurations.grettyHelperConfig
+            classpath = project.configurations.gretty
             main = 'org.akhikhl.gretty.Runner'
             args = [json]
             jvmArgs = project.gretty.jvmArgs


### PR DESCRIPTION
This commit makes it simple to add dependencies, such as JDBC drivers, to the Jetty classpath. This feature was available previously through the `grettyHelperConfig` configuration; however, I thought it would be more intuitive to have a documented configuration that was simply `gretty`.

Thanks for creating a great plugin!
