### PR TITLE
Added the capability to override the jvmArgs by passing them to the start/run script

### DIFF
--- a/libs/gretty-starter/src/main/groovy/org/akhikhl/gretty/GrettyStarter.groovy
+++ b/libs/gretty-starter/src/main/groovy/org/akhikhl/gretty/GrettyStarter.groovy
@@ -41,6 +41,16 @@ class GrettyStarter {
       sconfig[key] = value
     }
 
+    if(cliArgs){
+        def jvmArgs = []
+        cliArgs.eachWithIndex{ arg,index ->
+            if(index >0)
+                jvmArgs << arg
+        }
+        sconfig.jvmArgs = jvmArgs
+    }
+
+
     ConfigUtils.complementProperties(sconfig, ServerConfig.getDefaultServerConfig(config.productName))
 
     def resolveFile = { f ->


### PR DESCRIPTION
Added the capability to override the jvmArgs by passing them to the start/run script

ex : ./start.sh -Duser.language=en -Duser.region=US -Duser.timezone=GMT --XX:PermSize=128M -XX:MaxPermSize=256M -Xmx2000m -Xms2000m
