### PR TITLE
Manual reload mode

### DIFF
--- a/libs/gretty-runner/src/main/groovy/org/akhikhl/gretty/Runner.groovy
+++ b/libs/gretty-runner/src/main/groovy/org/akhikhl/gretty/Runner.groovy
@@ -29,6 +29,13 @@ final class Runner {
     }
   }
 
+  class RestartEvent implements ServerStartEvent {
+      @Override
+      void onServerStart(Map serverStartInfo) {
+          ServiceProtocol.send(params.statusPort, 'restartComplete')
+      }
+  }
+
   static void main(String[] args) {
     def cli = new CliBuilder()
     cli.with {
@@ -74,7 +81,7 @@ final class Runner {
         }
         else if(data == 'restart') {
           serverManager.stopServer()
-          serverManager.startServer()
+          serverManager.startServer(new RestartEvent())
         }
       }
     } finally {

--- a/libs/gretty-starter/src/main/groovy/org/akhikhl/gretty/ServerConfig.groovy
+++ b/libs/gretty-starter/src/main/groovy/org/akhikhl/gretty/ServerConfig.groovy
@@ -47,6 +47,7 @@ class ServerConfig {
   def realm
   def realmConfigFile
   def serverConfigFile
+  String reload
   Integer scanInterval
   def logbackConfigFile
   String loggingLevel
@@ -73,6 +74,7 @@ class ServerConfig {
     result.httpsEnabled = false
     result.servicePort = defaultServicePort
     result.statusPort = defaultStatusPort
+    result.reload = 'automatic'
     result.scanInterval = 1
     result.loggingLevel = 'INFO'
     result.consoleLogEnabled = true

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/JettyScannerManager.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/JettyScannerManager.groovy
@@ -210,6 +210,10 @@ final class JettyScannerManager implements ScannerManager {
 
   @Override
   void startScanner() {
+    if(sconfig.reload == 'manual') {
+        log.warn 'reload mode is manual, hot deployment disabled'
+        return
+    }
     if(!sconfig.scanInterval) {
       if(sconfig.scanInterval == null)
         log.warn 'scanInterval not specified, hot deployment disabled'


### PR DESCRIPTION
Hi again :)

I've added support for "manual" restart mode. It disables reload and changes gretty's behaviour after "Enter" key pressed: server is restarted instead of being shut down.

This "mode" will be useful if someone (like me :)) wants to manually recompile webapp (e.g. by calling inplaceWebapp task of Gretty plugin) and then restart server.

Old behaviour is kept for current users (reload = 'manual' is required option to activate this feature)
