### PR TITLE
interactiveMode does not disable scanner anymore

### DIFF
--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/JettyScannerManager.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/JettyScannerManager.groovy
@@ -210,10 +210,6 @@ final class JettyScannerManager implements ScannerManager {
 
   @Override
   void startScanner() {
-    if(sconfig.interactiveMode == 'restartOnKeyPress') {
-        log.warn 'interactiveMode is `restartOnKeyPress`, hot deployment disabled'
-        return
-    }
     if(!sconfig.scanInterval) {
       if(sconfig.scanInterval == null)
         log.warn 'scanInterval not specified, hot deployment disabled'


### PR DESCRIPTION
I mistook with disabling scanner when interactiveMode=restartOnKeyPress. I think user should be able to use restartOnKeyPress with scanner. :)
