### PR TITLE
Fixed ConnectException when restart was caused by Scanner

### DIFF
--- a/libs/gretty-runner/src/main/groovy/org/akhikhl/gretty/Runner.groovy
+++ b/libs/gretty-runner/src/main/groovy/org/akhikhl/gretty/Runner.groovy
@@ -81,6 +81,10 @@ final class Runner {
         }
         else if(data == 'restart') {
           serverManager.stopServer()
+          serverManager.startServer()
+        }
+        else if(data == 'restartWithEvent') {
+          serverManager.stopServer()
           serverManager.startServer(new RestartEvent())
         }
       }

--- a/libs/gretty-starter/src/main/groovy/org/akhikhl/gretty/LauncherBase.groovy
+++ b/libs/gretty-starter/src/main/groovy/org/akhikhl/gretty/LauncherBase.groovy
@@ -88,11 +88,11 @@ abstract class LauncherBase implements Launcher {
                     stopServer()
                     break infinite
                   } else {
-                    log.debug 'Sending command: {}', 'restart'
+                    log.debug 'Sending command: {}', 'restartWithEvent'
                     def futureStatus = executorService.submit({
                       ServiceProtocol.readMessage(sconfig.statusPort)
                     } as Callable)
-                    ServiceProtocol.send(sconfig.servicePort, 'restart')
+                    ServiceProtocol.send(sconfig.servicePort, 'restartWithEvent')
                     // Waiting for restart complete event
                     def status = futureStatus.get()
                     log.debug "Received status: ${status}"


### PR DESCRIPTION
Fixing a bug introduced by interactiveMode patch and reported by @elw00d :)

Scanner-triggered restart causes Runner to try to send 'restartComplete' message to status port but nobody listens to it in this case.

So I split 'restart' command into 'restart' (it will be called by Scanner) when no 'restartComplete' command will be sent and 'restartWithEvent' (it will be called by interactiveMode = 'restartOnKeyPress') with 'restartComplete' command.
