### PR TITLE
added scanDependencies option to add ProjectDependencies' sourceSets to scanner

### DIFF
--- a/libs/gretty-starter/src/main/groovy/org/akhikhl/gretty/WebAppConfig.groovy
+++ b/libs/gretty-starter/src/main/groovy/org/akhikhl/gretty/WebAppConfig.groovy
@@ -24,6 +24,10 @@ class WebAppConfig {
   def realmConfigFile
   def contextConfigFile
   def scanDirs
+  /**
+   * Specifies if Gretty should automatically add dependencyProjects' sourceSets to scanDirs
+   */
+  Boolean scanDependencies
   def fastReload
   Boolean recompileOnSourceChange
   Boolean reloadOnClassChange

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProjectUtils.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProjectUtils.groovy
@@ -9,6 +9,7 @@
 package org.akhikhl.gretty
 import org.apache.commons.io.FilenameUtils
 import org.gradle.api.Project
+import org.gradle.api.artifacts.ProjectDependency
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 /**
@@ -384,5 +385,9 @@ final class ProjectUtils {
       wconfig.contextConfigFile = new FileResolver(['webapp-tomcat', 'webapp-config' ]).resolveSingleFile(project, contextConfigFiles)
     } else
       wconfig.contextConfigFile = null
+  }
+
+  static List<Project> getDependencyProjects(Project project, String configurationName) {
+    project.configurations[configurationName].dependencies.withType(ProjectDependency).collect{ it.dependencyProject }
   }
 }


### PR DESCRIPTION
Hello!

I've added support for another option: now, one can specify `scanDependencies = true` and projects' project dependencies will be automatically added to scanner's scanDirs.

See more in _gretty-dev_ google group.

This may help for setups like described in #51.
