### PR TITLE
Added interactiveMode='rebuildAndRestartOnKeyPress' support

### DIFF
--- a/libs/gretty-starter/src/main/groovy/org/akhikhl/gretty/LauncherBase.groovy
+++ b/libs/gretty-starter/src/main/groovy/org/akhikhl/gretty/LauncherBase.groovy
@@ -64,6 +64,8 @@ abstract class LauncherBase implements Launcher {
 
   protected abstract void javaExec(JavaExecParams params)
 
+  protected abstract void rebuildWebapps()
+
   @Override
   void launch() {
     Thread thread = launchThread()
@@ -72,7 +74,7 @@ abstract class LauncherBase implements Launcher {
       ServiceProtocol.send(sconfig.servicePort, 'stop')
     }
     if(config.getInteractive()) {
-      if(sconfig.interactiveMode == 'restartOnKeyPress') {
+      if(sconfig.interactiveMode == 'restartOnKeyPress' || sconfig.interactiveMode == 'rebuildAndRestartOnKeyPress') {
         def hint = 'Press \'q\' or \'Q\' to stop the server or any other key to restart.'
         System.out.println hint
         ExecutorService executorService = Executors.newSingleThreadExecutor()
@@ -88,6 +90,9 @@ abstract class LauncherBase implements Launcher {
                     stopServer()
                     break infinite
                   } else {
+                    if(sconfig.interactiveMode == 'rebuildAndRestartOnKeyPress') {
+                      rebuildWebapps()
+                    }
                     log.debug 'Sending command: {}', 'restartWithEvent'
                     def futureStatus = executorService.submit({
                       ServiceProtocol.readMessage(sconfig.statusPort)

--- a/libs/gretty-starter/src/main/groovy/org/akhikhl/gretty/StarterLauncher.groovy
+++ b/libs/gretty-starter/src/main/groovy/org/akhikhl/gretty/StarterLauncher.groovy
@@ -64,6 +64,11 @@ class StarterLauncher extends LauncherBase {
   }
 
   @Override
+  protected void rebuildWebapps() {
+    println 'Cannot rebuild application in StarterLauncher'
+  }
+
+  @Override
   protected void writeRunConfigJson(json) {
     super.writeRunConfigJson(json)
     json.with {


### PR DESCRIPTION
Hi, I've added a new interactiveMode: rebuildAndRestartOnKeyPress. It will be usefull for setups with disabled source scanner like mentioned in #75.

This interactiveMode cannot be used in tasks that's depends on StarterLauncher as there's no dependency on gradle-api in gretty-starter project (and it shouldn't be as far as I know). But I think this won't be a problem because that tasks aren't interactive anyway.
