### PR TITLE
make depended projects inplace also

### DIFF
--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProjectUtils.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProjectUtils.groovy
@@ -66,6 +66,10 @@ final class ProjectUtils {
       addProjectClassPath = { Project proj ->
         urls.addAll proj.sourceSets.main.output.files.collect { it.toURI().toURL() }
         urls.addAll proj.configurations[dependencyConfig].files.collect { it.toURI().toURL() }
+		for (pd in proj.configurations[dependencyConfig].getAllDependencies().withType(ProjectDependency)) {
+ 			urls.addAll pd.getDependencyProject().sourceSets.main.output.files.collect { it.toURI().toURL() }
+ 			urls.remove pd.getDependencyProject().jar.archivePath.toURI().toURL()
+ 		}
         // ATTENTION: order of overlay classpath is important!
         if(proj.extensions.findByName('gretty'))
           for(String overlay in proj.gretty.overlays.reverse())


### PR DESCRIPTION
In solving the issue #92, it is more meaningful to define the issue as re-defining gretty's inplace property as not only making the web app project inplace but also making all the projects it depends on inplace.  That is, depended proejcts' sourceSets.main.output.files are put in the classpath instead of their archivePath. 
