### PR TITLE
exclude web-fragment project for inplace

### DIFF
--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProjectUtils.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProjectUtils.groovy
@@ -67,8 +67,13 @@ final class ProjectUtils {
         urls.addAll proj.sourceSets.main.output.files.collect { it.toURI().toURL() }
         urls.addAll proj.configurations[dependencyConfig].files.collect { it.toURI().toURL() }
 		for (pd in proj.configurations[dependencyConfig].getAllDependencies().withType(ProjectDependency)) {
- 			urls.addAll pd.getDependencyProject().sourceSets.main.output.files.collect { it.toURI().toURL() }
- 			urls.remove pd.getDependencyProject().jar.archivePath.toURI().toURL()
+			def p = pd.getDependencyProject()
+			if (!p.sourceSets.main.output.files.any {
+				new File(it, "META-INF/web-fragment.xml").exists()
+			}) {
+	 			urls.addAll p.sourceSets.main.output.files.collect { it.toURI().toURL() }
+	 			urls.remove p.jar.archivePath.toURI().toURL()
+			}
  		}
         // ATTENTION: order of overlay classpath is important!
         if(proj.extensions.findByName('gretty'))


### PR DESCRIPTION
web-fragment project should be excluded fro inplace since it is regulated in servlet 3.0 spec that web-fragment are jars put in in WEB-INF/lib. For inplace project, it is put under WEB-INF/classes.
