### PR TITLE
Allow multiple extraResourcePaths for tomcat 7

### DIFF
--- a/libs/gretty-runner-tomcat7/src/main/groovy/org/akhikhl/gretty/TomcatConfigurerImpl.groovy
+++ b/libs/gretty-runner-tomcat7/src/main/groovy/org/akhikhl/gretty/TomcatConfigurerImpl.groovy
@@ -75,10 +75,10 @@ class TomcatConfigurerImpl implements TomcatConfigurer {
 
     context.setDocBase(webappParams.resourceBase)
 
-    Map extraResourcePaths = [:]
+    List extraResourcePaths = []
 
     if(webappParams.extraResourceBases)
-      extraResourcePaths << webappParams.extraResourceBases.collectEntries { ['/', it ] }
+      extraResourcePaths += webappParams.extraResourceBases.collect { "/=$it" }
 
     Set classpathJarParentDirs = new LinkedHashSet()
 
@@ -88,11 +88,11 @@ class TomcatConfigurerImpl implements TomcatConfigurer {
       virtualWebInfLibs.add('/WEB-INF/lib/' + jarFile.name)
     }
 
-    extraResourcePaths << classpathJarParentDirs.collectEntries { [ '/WEB-INF/lib', it ] }
+    extraResourcePaths += classpathJarParentDirs.collect { "/WEB-INF/lib=$it" }
 
     if(extraResourcePaths) {
       VirtualDirContext vdc = new VirtualDirContext()
-      vdc.setExtraResourcePaths(extraResourcePaths.collect { it.key + '=' + it.value }.join(','))
+      vdc.setExtraResourcePaths(extraResourcePaths.join(','))
       context.setResources(vdc)
     }
   }


### PR DESCRIPTION
Using tomcat7 container.
When several extraResourceBases is added, only the last is applied.
This will fix it.

According to the documentation: http://tomcat.apache.org/tomcat-7.0-doc/config/resources.html#VirtualDirContext_implementation