### PR TITLE
Example of a bug - adding a Spring Web MVC app to the Spring Boot example farm results in an error

### DIFF
--- a/examples/spring-boot-farm/spring-boot-app/build.gradle
+++ b/examples/spring-boot-farm/spring-boot-app/build.gradle
@@ -16,6 +16,7 @@ farm {
   webapp project
   webapp ':spring-boot-farm:spring-boot-webservice'
   webapp ':spring-boot-farm:jee-webservice'
+  webapp ':spring-boot-farm:spring-web-mvc-webservice'
 }
 
 ext {

--- a/examples/spring-boot-farm/spring-web-mvc-webservice/build.gradle
+++ b/examples/spring-boot-farm/spring-web-mvc-webservice/build.gradle
@@ -1,0 +1,7 @@
+apply plugin: 'war'
+apply plugin: 'org.akhikhl.gretty'
+apply from: rootProject.file('integrationTests.gradle')
+
+dependencies {
+    compile "org.springframework:spring-webmvc:4.1.2.RELEASE"
+}

--- a/examples/spring-boot-farm/spring-web-mvc-webservice/src/main/java/org/akhikhl/examples/gretty/springmvcapp/MyMvcController.java
+++ b/examples/spring-boot-farm/spring-web-mvc-webservice/src/main/java/org/akhikhl/examples/gretty/springmvcapp/MyMvcController.java
@@ -1,0 +1,14 @@
+package org.akhikhl.examples.gretty.springmvcapp;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("test")
+public class MyMvcController {
+    @RequestMapping(method = RequestMethod.GET)
+    public String test() {
+        return "MVC TEST";
+    }
+}

--- a/examples/spring-boot-farm/spring-web-mvc-webservice/src/main/java/org/akhikhl/examples/gretty/springmvcapp/WebAppInitializer.java
+++ b/examples/spring-boot-farm/spring-web-mvc-webservice/src/main/java/org/akhikhl/examples/gretty/springmvcapp/WebAppInitializer.java
@@ -1,0 +1,27 @@
+package org.akhikhl.examples.gretty.springmvcapp;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletRegistration;
+
+import org.springframework.web.WebApplicationInitializer;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+
+public class WebAppInitializer implements WebApplicationInitializer {
+    @Override
+    public void onStartup(ServletContext container) {
+        WebApplicationContext appContext = getContext();
+
+        ServletRegistration.Dynamic dispatcher = container.addServlet(
+                "dispatcher", new DispatcherServlet(appContext));
+        dispatcher.setLoadOnStartup(1);
+        dispatcher.addMapping("/");
+    }
+
+    private AnnotationConfigWebApplicationContext getContext() {
+        AnnotationConfigWebApplicationContext context = new AnnotationConfigWebApplicationContext();
+        context.setConfigLocation("org.akhikhl.examples.gretty.springmvcapp");
+        return context;
+    }
+}

--- a/examples/spring-boot-farm/spring-web-mvc-webservice/src/main/java/org/akhikhl/examples/gretty/springmvcapp/WebConfig.java
+++ b/examples/spring-boot-farm/spring-web-mvc-webservice/src/main/java/org/akhikhl/examples/gretty/springmvcapp/WebConfig.java
@@ -1,0 +1,12 @@
+package org.akhikhl.examples.gretty.springmvcapp;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+@EnableWebMvc
+@Configuration
+@ComponentScan(basePackages = "org.akhikhl.examples.gretty.springmvcapp")
+public class WebConfig extends WebMvcConfigurerAdapter {
+}


### PR DESCRIPTION
Hi,

this is an example demonstrating issue #135. When you run 

    ./gradlew spring-boot-farm:spring-boot-app:farmRun

from the `examples` directory, you get an error similar to the following:

    15:38:34     WARN  o.e.j.u.component.AbstractLifeCycle - FAILED org.springframework.boot.context.embedded.jetty.ServletContextInitializerConfiguration$InitializerListener@fb0a08c: java.lang.IllegalStateException: Multiple servlets map to path: /: dispatcherServlet,dispatcher
    java.lang.IllegalStateException: Multiple servlets map to path: /: dispatcherServlet,dispatcher
    at org.eclipse.jetty.servlet.ServletHandler.updateMappings(ServletHandler.java:1488) ~[jetty-servlet-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.servlet.ServletHandler.setServletMappings(ServletHandler.java:1585) ~[jetty-servlet-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.servlet.ServletHandler.addServletMapping(ServletHandler.java:1023) ~[jetty-servlet-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.servlet.ServletHolder$Registration.addMapping(ServletHolder.java:1015) ~[jetty-servlet-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.springframework.boot.context.embedded.ServletRegistrationBean.configure(ServletRegistrationBean.java:186) ~[spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
    at org.springframework.boot.context.embedded.ServletRegistrationBean.onStartup(ServletRegistrationBean.java:172) ~[spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
    at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext$1.onStartup(EmbeddedWebApplicationContext.java:203) ~[spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
    at org.springframework.boot.context.embedded.jetty.ServletContextInitializerConfiguration$InitializerListener.doStart(ServletContextInitializerConfiguration.java:66) ~[spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
    at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68) [jetty-util-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:132) [jetty-util-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:106) [jetty-util-9.2.7.16.jar:9.2.7.v20150116]
    at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61) [jetty-server-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.server.handler.ScopedHandler.doStart(ScopedHandler.java:120) [jetty-server-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.server.handler.ContextHandler.startContext(ContextHandler.java:784) [jetty-server-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:294) [jetty-servlet-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.webapp.WebAppContext.startWebapp(WebAppContext.java:1349) [jetty-webapp-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.webapp.WebAppContext.startContext(WebAppContext.java:1342) [jetty-webapp-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:741) [jetty-server-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.webapp.WebAppContext.doStart(WebAppContext.java:505) [jetty-webapp-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.akhikhl.gretty.JettyWebAppContext.super$10$doStart(JettyWebAppContext.groovy) [gretty-runner-jetty9-1.1.9-SNAPSHOT.jar:na]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0]
    at java.lang.reflect.Method.invoke(Method.java:483) ~[na:1.8.0]
    at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:90) [groovy-all-2.4.0.jar:2.4.0]
    at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:324) [groovy-all-2.4.0.jar:2.4.0]
    at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1208) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.invokeMethodOnSuperN(ScriptBytecodeAdapter.java:130) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.ytecodeAdapter.invokeMethodOnSuper0(ScriptBytecodeAdapter.java:150) [groovy-all-2.4.0.jar:2.4.0]
    at org.akhikhl.gretty.JettyWebAppContext.doStart(JettyWebAppContext.groovy:43) [gretty-runner-jetty9-1.1.9-SNAPSHOT.jar:na]
    at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68) [jetty-util-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:132) [jetty-util-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:114) [jetty-util-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61) [jetty-server-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.server.handler.ContextHandlerCollection.doStart(ContextHandlerCollection.java:163) [jetty-server-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68) [jetty-util-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:132) [jetty-util-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.server.Server.start(Server.java:387) [jetty-server-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:114) [jetty-util-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61) [jetty-server-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.server.Server.doStart(Server.java:354) [jetty-server-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68) [jetty-util-9.2.7.v20150116.jar:9.2.7.v20150116]
    at org.springframework.boot.context.embedded.jetty.JettyEmbeddedServletContainer.initialize(JettyEmbeddedServletContainer.java:76) [spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
    at org.springrk.boot.context.embedded.jetty.JettyEmbeddedServletContainer.<init>(JettyEmbeddedServletContainer.java:65) [spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
    at org.akhikhl.gretty.JettyServletContainer.<init>(JettyServletContainer.groovy:24) [gretty-runner-spring-boot-jetty-1.1.9-SNAPSHOT.jar:na]
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) [na:1.8.0]
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) [na:1.8.0]
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) [na:1.8.0]
    at java.lang.reflect.Constructor.newInstance(Constructor.java:408) [na:1.8.0]
    at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:77) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrapNoCoerce.callConstructor(ConstructorSite.java:102) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallConstructor(CallSiteArray.java:57) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:230) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:250) [groovy-all-2.4.0.jar:2.4.0]
    at org.akhikhl.gretty.JettyServletContainerFactory.getEmbeddedServletContainer(JettyServletContainerFactory.groovy:64) [gretty-runner-spring-boot-jetty-1.1.9-SNAPSHOT.jar:na]
    at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.createEmbeddedServletContainer(EmbeddedWebApplicationContext.java:148) [spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
    at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.onRefresh(EmbeddedWebApplicationContext.java:121) [spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
    at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:476) [spring-context-4.0.8.RELEASE.jar:4.0.8.RELEASE                                                                                                                                                         ]
    at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.refresh(EmbeddedWebApplicationContext.java:109) [spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
    at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:691) [spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
    at org.springframework.boot.SpringApplication.run(SpringApplication.java:320) [spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
    at org.springframework.boot.SpringApplication.run(SpringApplication.java:952) [spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
    at org.springframework.boot.SpringApplication.run(SpringApplication.java:941) [spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
    at org.springframework.boot.SpringApplication$run.call(Unknown Source) [spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
    at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:128) [groovy-all-2.4.0.jar:2.4.0]
    at org.akhikhl.examples.gretty.springbootapp.Application.main(Application.groovy:24) [main/:na]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0]
    at java.lang.reflect.Method.invoke(Method.java:483) ~[na:1.8.0]
    at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:90) [groovy-all-2.4.0.jar:2.4.0]
    at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:324) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.StaticMetaMethodSite.invoke(StaticMetaMethodSite.java:43) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.StaticMetaMethodSite.call(StaticMetaMethodSite.java:88) [groovy-all-2.4.0.jar:2.4.0]
    at ehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:120) [groovy-all-2.4.0.jar:2.4.0]
    at org.akhikhl.gretty.SpringBootServerManager.startServer(SpringBootServerManager.groovy:50) [gretty-runner-spring-boot-1.1.9-SNAPSHOT.jar:na]
    at org.akhikhl.gretty.ServerManager$startServer$0.call(Unknown Source) [gretty-runner-1.1.9-SNAPSHOT.jar:na]
    at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:120) [groovy-all-2.4.0.jar:2.4.0]
    at org.akhikhl.gretty.Runner.run(Runner.groovy:70) [gretty-runner-1.1.9-SNAPSHOT.jar:na]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0]
    at java.lang.reflect.Method.invoke(Method.java:483) ~[na:1.8.0]
    at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:207) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.call(PogoMetaMethodSite.java:68) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:112) [groovy-all-2.4.0.jar:2.4.0]
    at org.akhikhl.Runner.main(Runner.groovy:48) [gretty-runner-1.1.9-SNAPSHOT.jar:na]
    15:38:34     WARN  o.e.jetty.webapp.WebAppContext - Failed startup of context o.a.g.JettyWebAppContext@5ec46cdd{/spring-web-mvc-webservice,file:/aruka/baltona-mdm/gretty-sources/examples/spring-boot-farm/spring-web-mvc-webservice/build/inplaceWebapp/,STARTING}
    java.lang.IllegalStateException: Multiple servlets map to path: /: dispatcherServlet,dispatcher
        at org.eclipse.jetty.servlet.ServletHandler.updateMappings(ServletHandler.java:1488) ~[jetty-servlet-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.servlet.ServletHandler.setServletMappings(ServletHandler.java:1585) ~[jetty-servlet-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.servlet.ServletHandler.addServletMapping(ServletHandler.java:1023) ~[jetty-servlet-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.servlet.ServletHolder$Registration.addMapping(ServletHolder.java:1015) ~[jetty-servlet-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.springframework.boot.context.embedded.ServletRegistrationBean.configure(ServletRegistrationBean.java:186) ~[spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
        at org.springframework.boot.context.embedded.ServletRegistrationBean.onStartup(ServletRegistrationBean.java:172) ~[spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
        at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext$1.onStartup(EmbeddedWebApplicationContext.java:203) ~[spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
        at org.springframework.boot.context.embedded.jetty.ServletContextInitializerConfiguration$InitializerListener.doStart(ServletContextInitializerConfiguration.java:66) ~[spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68) [jetty-util-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:132) [jetty-util-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:106) [jetty-util-9.2.7.v20150116.jar:90150116]
        at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61) [jetty-server-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.server.handler.ScopedHandler.doStart(ScopedHandler.java:120) ~[jetty-server-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.server.handler.ContextHandler.startContext(ContextHandler.java:784) ~[jetty-server-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:294) ~[jetty-servlet-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.webapp.WebAppContext.startWebapp(WebAppContext.java:1349) ~[jetty-webapp-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.webapp.WebAppContext.startContext(WebAppContext.java:1342) ~[jetty-webapp-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:741) ~[jetty-server-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.webapp.WebAppContext.doStart(WebAppContext.java:505) ~[jetty-webapp-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.akhikhl.gretty.JettyWebAppContext.super$10$doStart(JettyWebAppContext.groovy) [gretty-runner-jetty9-1.1.9-SNAPSHOT.jar:na]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0]
        at java.lang.reflect.Method.invoke(Method.java:483) ~[na:1.8.0]
        at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:90) [groovy-all-2.4.0.jar:2.4.0]
        at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:324) [groovy-all-2.4.0.jar:2.4.0]
        at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1208) [groovy-all-2.4.0.jar:2.4.0]
        at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.invokeMethodOnSuperN(ScriptBytecodeAdapter.java:130) [groovy-all-2.4.0.jar:2.4.0]
        at org.codehaus.groovy.runtime.ScriptBydapter.invokeMethodOnSuper0(ScriptBytecodeAdapter.java:150) [groovy-all-2.4.0.jar:2.4.0]
        at org.akhikhl.gretty.JettyWebAppContext.doStart(JettyWebAppContext.groovy:43) [gretty-runner-jetty9-1.1.9-SNAPSHOT.jar:na]
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68) [jetty-util-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:132) [jetty-util-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:114) [jetty-util-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61) [jetty-server-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.server.handler.ContextHandlerCollection.doStart(ContextHandlerCollection.java:163) [jetty-server-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68) [jetty-util-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:132) [jetty-util-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.server.Server.start(Server.java:387) [jetty-server-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:114) [jetty-util-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61) [jetty-server-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.server.Server.doStart(Server.java:354) [jetty-server-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68) [jetty-util-9.2.7.v20150116.jar:9.2.7.v20150116]
        at org.springframework.boot.context.embedded.jetty.JettyEmbeddedServletContainer.initialize(JettyEmbeddedServletContainer.java:76) [spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
        at org.springframeworcontext.embedded.jetty.JettyEmbeddedServletContainer.<init>(JettyEmbeddedServletContainer.java:65) [spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
        at org.akhikhl.gretty.JettyServletContainer.<init>(JettyServletContainer.groovy:24) [gretty-runner-spring-boot-jetty-1.1.9-SNAPSHOT.jar:na]
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) [na:1.8.0]
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) [na:1.8.0]
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) [na:1.8.0]
        at java.lang.reflect.Constructor.newInstance(Constructor.java:408) [na:1.8.0]
        at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:77) [groovy-all-2.4.0.jar:2.4.0]
        at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrapNoCoerce.callConstructor(ConstructorSite.java:102) [groovy-all-2.4.0.jar:2.4.0]
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallConstructor(CallSiteArray.java:57) [groovy-all-2.4.0.jar:2.4.0]
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:230) [groovy-all-2.4.0.jar:2.4.0]
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:250) [groovy-all-2.4.0.jar:2.4.0]
        at org.akhikhl.gretty.JettyServletContainerFactory.getEmbeddedServletContainer(JettyServletContainerFactory.groovy:64) [gretty-runner-spring-boot-jetty-1.1.9-SNAPSHOT.jar:na]
        at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.createEmbeddedServletContainer(EmbeddedWebApplicationContext.java:148) [spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
        at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.onRefresh(EmbeddedWebApplicationContext.java:121) [spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
        at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:476) [spring-context-4.0.8.RELEASE.jar:4.0.8.RELEASE]
          g.springframework.boot.context.embedded.EmbeddedWebApplicationContext.refresh(EmbeddedWebApplicationContext.java:109) [spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
        at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:691) [spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:320) [spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:952) [spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:941) [spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
        at org.springframework.boot.SpringApplication$run.call(Unknown Source) [spring-boot-1.1.9.RELEASE.jar:1.1.9.RELEASE]
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45) [groovy-all-2.4.0.jar:2.4.0]
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108) [groovy-all-2.4.0.jar:2.4.0]
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:128) [groovy-all-2.4.0.jar:2.4.0]
        at org.akhikhl.examples.gretty.springbootapp.Application.main(Application.groovy:24) [main/:na]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0]
    at java.lang.reflect.Method.invoke(Method.java:483) ~[na:1.8.0]
    at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:90) [groovy-all-2.4.0.jar:2.4.0]
    at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:324) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.StaticMetaMethodSite.invoke(StaticMetaMethodSite.java:43) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.StaticMetaMethodSite.call(StaticMetaMethodSite.java:88) [groovy-all-2.4.0.jar:2.4.0]
    at org.codeoovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:120) [groovy-all-2.4.0.jar:2.4.0]
    at org.akhikhl.gretty.SpringBootServerManager.startServer(SpringBootServerManager.groovy:50) [gretty-runner-spring-boot-1.1.9-SNAPSHOT.jar:na]
    at org.akhikhl.gretty.ServerManager$startServer$0.call(Unknown Source) [gretty-runner-1.1.9-SNAPSHOT.jar:na]
    at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:120) [groovy-all-2.4.0.jar:2.4.0]
    at org.akhikhl.gretty.Runner.run(Runner.groovy:70) [gretty-runner-1.1.9-SNAPSHOT.jar:na]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0]
    at java.lang.reflect.Method.invoke(Method.java:483) ~[na:1.8.0]
    at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:207) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.call(PogoMetaMethodSite.java:68) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108) [groovy-all-2.4.0.jar:2.4.0]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:112) [groovy-all-2.4.0.jar:2.4.0]
    at org.akhikhl.gretty.Rain(Runner.groovy:48) [gretty-runner-1.1.9-SNAPSHOT.jar:na]


