### PR TITLE
Fix Java 1.6 compatibility

### DIFF
--- a/libs/gretty-runner-tomcat/src/main/java/org/akhikhl/gretty/FilteringClassLoader.java
+++ b/libs/gretty-runner-tomcat/src/main/java/org/akhikhl/gretty/FilteringClassLoader.java
@@ -50,7 +50,7 @@ public class FilteringClassLoader extends URLClassLoader {
   public Enumeration<URL> getResources(String name) throws IOException {
     for(String serverResource : serverResources)
       if(name.startsWith(serverResource))
-        return Collections.emptyEnumeration();
+        return Collections.enumeration(Collections.<URL>emptySet());
     return super.getResources(name);
   }
 }


### PR DESCRIPTION
Method `emptyEnumeration()` is available since 1.7

The patch allows gretty to execute on 1.6