### PR TITLE
Don't add appRun as the dependency of task run if the run task exists

### DIFF
--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/GrettyPlugin.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/GrettyPlugin.groovy
@@ -285,8 +285,6 @@ class GrettyPlugin implements Plugin<Project> {
         description = 'Starts web-app inplace, in interactive mode.'
       }
 
-      project.tasks.run.dependsOn 'appRun'
-
       project.task('appRunDebug', type: AppStartTask, group: 'gretty') {
         description = 'Starts web-app inplace, in debug and interactive mode.'
         debug = true
@@ -664,10 +662,13 @@ class GrettyPlugin implements Plugin<Project> {
       tomcat8ServletApiVersion = Externalized.getString('tomcat8ServletApiVersion')
     }
 
-    if(!project.tasks.findByName('run'))
+    if(!project.tasks.findByName('run')) {
       project.task('run', group: 'gretty') {
         description = 'Starts web-app inplace, in interactive mode. Same as appRun task.'
       }
+
+      project.tasks.run.dependsOn 'appRun'
+    }
 
     if(!project.tasks.findByName('debug'))
       project.task('debug', group: 'gretty') {


### PR DESCRIPTION
build.gradle
```Gradle
buildscript {
    repositories {
        //mavenLocal()
        jcenter()
    }

    dependencies {
        classpath 'org.akhikhl.gretty:gretty:+'
    }
}

repositories {
    mavenLocal()
    jcenter()
}

apply plugin: 'java'
apply plugin: 'application'
apply plugin: 'org.akhikhl.gretty'

run {
    mainClassName = 'test.Test'
}
```
The application plugin is applied, which adds a "run" task, but gretty plugin adds the task "appRun" as the dependency of task "run", so executing `./gradlew run` will execute the task "appRun" first, then task "run". And this is not expected. 

The dependency is shown as below:
```
#gradle tasks --all
...
run - Runs this project as a JVM application [appRun, classes]
```