### PR TITLE
 Added filter to control jetty9 annotation scanning #188

### DIFF
--- a/libs/gretty-core/src/main/groovy/org/akhikhl/gretty/LauncherBase.groovy
+++ b/libs/gretty-core/src/main/groovy/org/akhikhl/gretty/LauncherBase.groovy
@@ -359,6 +359,9 @@ abstract class LauncherBase implements Launcher {
             contextConfigFile self.fileToString(wconfig.contextConfigFile)
           if(wconfig.springBootMainClass)
             springBootMainClass wconfig.springBootMainClass
+          if(wconfig.webInfIncludeJarPattern)
+            webInfIncludeJarPattern wconfig.webInfIncludeJarPattern
+
         }
       }
     }

--- a/libs/gretty-core/src/main/groovy/org/akhikhl/gretty/WebAppConfig.groovy
+++ b/libs/gretty-core/src/main/groovy/org/akhikhl/gretty/WebAppConfig.groovy
@@ -38,6 +38,7 @@ class WebAppConfig {
   List extraResourceBases
 
   Set<String> classPath
+  String webInfIncludeJarPattern
 
   String projectPath
   Boolean inplace

--- a/libs/gretty-runner-jetty9/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
+++ b/libs/gretty-runner-jetty9/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
@@ -199,7 +199,9 @@ class JettyConfigurerImpl implements JettyConfigurer {
   @Override
   def createWebAppContext(Map serverParams, Map webappParams) {
     List<String> webappClassPath = webappParams.webappClassPath
+    String webappClasspathScanPattern = webappParams.webInfIncludeJarPattern
     JettyWebAppContext context = new JettyWebAppContext()
+    context.setAttribute("org.eclipse.jetty.server.webapp.WebInfIncludeJarPattern", webappClasspathScanPattern)
     context.setWebInfLib(webappClassPath.findAll { it.endsWith('.jar') && !isServletApi(it) }.collect { new File(it) })
     context.setExtraClasspath(webappClassPath.collect { it.endsWith('.jar') ? it : (it.endsWith('/') ? it : it + '/') }.findAll { !isServletApi(it) }.join(';'))
     context.setInitParameter('org.eclipse.jetty.servlet.Default.useFileMappedBuffer', serverParams.productMode ? 'true' : 'false')


### PR DESCRIPTION
Added a parameter "webInfIncludeJarPattern" for webapp's that can filter what libraries under WEB-INF/lib that are scanned for annotations. See https://wiki.eclipse.org/Jetty/Howto/Avoid_slow_deployment for more info.
usage:

```
farm {
 webapp 'myGroup:myArtifact:@war', webInfIncludeJarPattern: ".*/.*foo-api-[^/]\\.jar\$"
}
```
