### PR TITLE
Replace groovy-all with the specific Groovy modules

### DIFF
--- a/examples/spring-boot-farm-secure/spring-boot-app/build.gradle
+++ b/examples/spring-boot-farm-secure/spring-boot-app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'org.akhikhl.gretty'
 apply from: rootProject.file('integrationTests.gradle')
 
 dependencies {
-  compile "org.codehaus.groovy:groovy-all:$groovy_version"
+  compile "org.codehaus.groovy:groovy:$groovy_version"
   compile 'org.webjars:bootstrap:3.2.0'
   compile 'org.webjars:jquery:2.1.1'
 }

--- a/examples/spring-boot-farm-secure/spring-boot-webservice/build.gradle
+++ b/examples/spring-boot-farm-secure/spring-boot-webservice/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'org.akhikhl.gretty'
 apply from: rootProject.file('integrationTests.gradle')
 
 dependencies {
-  compile "org.codehaus.groovy:groovy-all:$groovy_version"
+  compile "org.codehaus.groovy:groovy:$groovy_version"
   testCompile "org.akhikhl.gretty:gretty-spock:$gretty_version"
 }
 

--- a/examples/spring-boot-farm/spring-boot-app/build.gradle
+++ b/examples/spring-boot-farm/spring-boot-app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'org.akhikhl.gretty'
 apply from: rootProject.file('integrationTests.gradle')
 
 dependencies {
-  compile "org.codehaus.groovy:groovy-all:$groovy_version"
+  compile "org.codehaus.groovy:groovy:$groovy_version"
   compile 'org.webjars:bootstrap:3.2.0'
   compile 'org.webjars:jquery:2.1.1'
 }

--- a/examples/spring-boot-farm/spring-boot-webservice1/build.gradle
+++ b/examples/spring-boot-farm/spring-boot-webservice1/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'org.akhikhl.gretty'
 apply from: rootProject.file('integrationTests.gradle')
 
 dependencies {
-  compile "org.codehaus.groovy:groovy-all:$groovy_version"
+  compile "org.codehaus.groovy:groovy:$groovy_version"
   testCompile "org.akhikhl.gretty:gretty-spock:$gretty_version"
 }
 

--- a/examples/spring-boot-farm/spring-boot-webservice2/build.gradle
+++ b/examples/spring-boot-farm/spring-boot-webservice2/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'org.akhikhl.gretty'
 apply from: rootProject.file('integrationTests.gradle')
 
 dependencies {
-  compile "org.codehaus.groovy:groovy-all:$groovy_version"
+  compile "org.codehaus.groovy:groovy:$groovy_version"
   testCompile "org.akhikhl.gretty:gretty-spock:$gretty_version"
 }
 

--- a/examples/spring-boot-simple/build.gradle
+++ b/examples/spring-boot-simple/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'org.akhikhl.gretty'
 apply from: rootProject.file('integrationTests.gradle')
 
 dependencies {
-  compile "org.codehaus.groovy:groovy-all:$groovy_version"
+  compile "org.codehaus.groovy:groovy:$groovy_version"
   compile 'org.webjars:bootstrap:3.2.0'
   compile 'org.webjars:jquery:2.1.1'
   // We use Velocity for example of template processing within the webapp.

--- a/examples/testWar/build.gradle
+++ b/examples/testWar/build.gradle
@@ -38,7 +38,7 @@ task integrationTest(type: Test, dependsOn: 'test') {
 
 dependencies {
   // specific to concrete test harness
-  testCompile "org.codehaus.groovy:groovy-all:$groovy_version"
+  testCompile "org.codehaus.groovy:groovy:$groovy_version"
   testCompile "org.spockframework:spock-core:$spock_version"
   testCompile "org.gebish:geb-spock:$gebVersion"
   testCompile "org.seleniumhq.selenium:selenium-support:$seleniumVersion"

--- a/libs/gretty-core/build.gradle
+++ b/libs/gretty-core/build.gradle
@@ -3,7 +3,8 @@ apply from: rootProject.file('libs/common.gradle')
 import org.apache.tools.ant.filters.*
 
 dependencies {
-  compile "org.codehaus.groovy:groovy-all:$groovy_version"
+  compile "org.codehaus.groovy:groovy:$groovy_version"
+  compile "org.codehaus.groovy:groovy-json:$groovy_version"
   compile "ch.qos.logback:logback-classic:$logback_version"
   compile 'commons-cli:commons-cli:1.2'
   compile 'commons-configuration:commons-configuration:1.10'

--- a/libs/gretty-filter/build.gradle
+++ b/libs/gretty-filter/build.gradle
@@ -5,7 +5,9 @@ dependencies {
   compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1', {
     exclude group: 'commons-logging', module: 'commons-logging'
   }
-  compile "org.codehaus.groovy:groovy-all:${groovy_version}"
+  compile "org.codehaus.groovy:groovy:${groovy_version}"
+  compile "org.codehaus.groovy:groovy-servlet:${groovy_version}"
+  compile "org.codehaus.groovy:groovy-jmx:${groovy_version}"
   compile "org.slf4j:slf4j-api:$slf4j_version"
   compile "org.slf4j:jcl-over-slf4j:$slf4j_version"
 }

--- a/libs/gretty-runner/build.gradle
+++ b/libs/gretty-runner/build.gradle
@@ -1,7 +1,8 @@
 apply from: rootProject.file('libs/common.gradle')
 
 dependencies {
-  compile "org.codehaus.groovy:groovy-all:$groovy_version"
+  compile "org.codehaus.groovy:groovy:$groovy_version"
+  compile "org.codehaus.groovy:groovy-json:$groovy_version"
   compile 'commons-cli:commons-cli:1.2'
   compile 'commons-io:commons-io:2.4'
   compile "ch.qos.logback:logback-classic:$logback_version"

--- a/libs/gretty-spock/build.gradle
+++ b/libs/gretty-spock/build.gradle
@@ -1,7 +1,7 @@
 apply from: rootProject.file('libs/common.gradle')
 
 dependencies {
-  compile "org.codehaus.groovy:groovy-all:${groovy_version}"
+  compile "org.codehaus.groovy:groovy:${groovy_version}"
   compile "org.spockframework:spock-core:$spock_version"
   compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
 }

--- a/libs/gretty-springboot/build.gradle
+++ b/libs/gretty-springboot/build.gradle
@@ -2,7 +2,7 @@ apply from: rootProject.file('libs/common.gradle')
 
 dependencies {
   providedCompile 'javax.servlet:javax.servlet-api:3.0.1'
-  compile "org.codehaus.groovy:groovy-all:$groovy_version"
+  compile "org.codehaus.groovy:groovy:$groovy_version"
   compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion", {
     exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
   }


### PR DESCRIPTION
Andrey,

Thank you for this great plugin and your work. Gretty makes our job much easier. 

Recently we run into a problem and this pull request solves that problem. But let me explain first.

Using `groovy-all` is in my opinion not the prefered way to declare Groovy dependencies. This pull request replaces the `groovy-all` dependency with the actual Groovy dependencies such as `groovy`, `groovy-json`, `groovy-servlet` and `groovy-jmx`.

**Why does it matter?**

In our project we declare each dependencies specifically for each Groovy module and we are forcing Gradle to remove any `groovy-all` dependencies (see listing below).

```
configurations.all {
        resolutionStrategy {
            eachDependency { DependencyResolveDetails details ->
                //changing 'groovy-all' into 'groovy':
                if (details.requested.name == 'groovy-all') {
                    details.useTarget group: details.requested.group, name: 'groovy', version: groovyVersion
                }
            }
        }
}
```
Since Gretty declares a dependency of `groovy-all`, even the specific Gretty module does not need all Groovy modules united in the `groovy-all` JAR, the plugin fails to start with a `ClassNotFoundException``

```
Exception in thread "main" java.lang.NoClassDefFoundError: groovy/json/JsonSlurper
        at org.akhikhl.gretty.Runner.run(Runner.groovy:114)
        at org.akhikhl.gretty.Runner.this$2$run(Runner.groovy)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:497)
        at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:210)
        at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.call(PogoMetaMethodSite.java:71)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:117)
        at org.akhikhl.gretty.Runner.main(Runner.groovy:46)
Caused by: java.lang.ClassNotFoundException: groovy.json.JsonSlurper
        at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        ... 12 more
```
We did not manage to workaround this exception. Even defining the missing `groovy-json` dependency did not solve the problem.

Would you consider to apply this pull request and release a new version of Gretty?

Kind regards
Silvio