### PR TITLE
Gradle 2.14/Jacoco-related startup error #265

### DIFF
--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/GrettyExtension.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/GrettyExtension.groovy
@@ -16,6 +16,7 @@ class GrettyExtension extends GrettyConfig {
 
   int debugPort = 5005
   boolean debugSuspend = true
+  boolean jacocoEnabled = true;
 
   protected List overlays = []
 

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/StartBaseTask.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/StartBaseTask.groovy
@@ -104,7 +104,7 @@ abstract class StartBaseTask extends DefaultTask {
   }
 
   JacocoTaskExtension getJacoco() {
-    if(jacocoHelper == null && project.extensions.findByName('jacoco')) {
+    if(jacocoHelper == null && project.extensions.findByName('jacoco') && project.gretty.jacocoEnabled) {
       jacocoHelper = new JacocoHelper(this)
       jacocoHelper.jacoco.enabled = getDefaultJacocoEnabled()
     }


### PR DESCRIPTION
This is a workaround that I threw together for issue #265 which I reported today.  Three things worth noting right off the bat:

1) this is my first gradle plugin coding experience
2) this is my first github pull request
3) this only avoids the real jacoco api mismatch if your usecase does not need to generate code coverage

So this is likely of limited value.  But I needed to get this resolved for our situation and figured I'd share in case it was helpful.  If there's any etiquette or de-facto standards I've unknowingly disregarded, please let me know.
