### PR TITLE
fix for #147 - gretty won't resolve the runtime configuration anymore…

### DIFF
--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/GrettyPlugin.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/GrettyPlugin.groovy
@@ -124,8 +124,7 @@ class GrettyPlugin implements Plugin<Project> {
 
     def runtimeConfig = project.configurations.findByName('runtime')
     if(runtimeConfig) {
-      def artifacts = runtimeConfig.copyRecursive().resolvedConfiguration.resolvedArtifacts
-      if(artifacts.find { it.name == 'slf4j-api' } && !artifacts.find { it.name in ['slf4j-nop', 'slf4j-simple', 'slf4j-log4j12', 'slf4j-jdk14', 'logback-classic', 'log4j-slf4j-impl'] }) {
+      if(runtimeConfig.allDependencies.find { it.name == 'slf4j-api' } && !runtimeConfig.allDependencies.find { it.name in ['slf4j-nop', 'slf4j-simple', 'slf4j-log4j12', 'slf4j-jdk14', 'logback-classic', 'log4j-slf4j-impl'] }) {
         project.dependencies {
           compile "org.slf4j:slf4j-nop:$slf4jVersion"
         }


### PR DESCRIPTION
… in 'afterEvaluate' hook

The new code also checks whether the 'slf4j-nop' dependencies is to be add but without resolving the whole configuration.