### PR TITLE
On jetty93 allow JSTL TLDs to be found by default

### DIFF
--- a/libs/gretty-runner-jetty93/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
+++ b/libs/gretty-runner-jetty93/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
@@ -208,7 +208,9 @@ class JettyConfigurerImpl implements JettyConfigurer {
     context.setWebInfLib(webappClassPath.findAll { it.endsWith('.jar') && !isServletApi(it) }.collect { new File(it) })
     context.setExtraClasspath(webappClassPath.collect { it.endsWith('.jar') ? it : (it.endsWith('/') ? it : it + '/') }.findAll { !isServletApi(it) }.join(';'))
     context.setInitParameter('org.eclipse.jetty.servlet.Default.useFileMappedBuffer', serverParams.productMode ? 'true' : 'false')
-    FilteringClassLoader classLoader = new FilteringClassLoader(getClass().getClassLoader(), context)
+    context.setAttribute('org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern',
+            '.*/[^/]*servlet-api-[^/]*\\.jar$|.*/javax.servlet.jsp.jstl-.*\\.jar$|.*/[^/]*taglibs.*\\.jar$');
+    FilteringClassLoader classLoader = new FilteringClassLoader(context)
     classLoader.addServerClass('ch.qos.logback.')
     classLoader.addServerClass('org.slf4j.')
     classLoader.addServerClass('org.codehaus.groovy.')

--- a/libs/gretty-runner-jetty93/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
+++ b/libs/gretty-runner-jetty93/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
@@ -208,7 +208,7 @@ class JettyConfigurerImpl implements JettyConfigurer {
     context.setWebInfLib(webappClassPath.findAll { it.endsWith('.jar') && !isServletApi(it) }.collect { new File(it) })
     context.setExtraClasspath(webappClassPath.collect { it.endsWith('.jar') ? it : (it.endsWith('/') ? it : it + '/') }.findAll { !isServletApi(it) }.join(';'))
     context.setInitParameter('org.eclipse.jetty.servlet.Default.useFileMappedBuffer', serverParams.productMode ? 'true' : 'false')
-    FilteringClassLoader classLoader = new FilteringClassLoader(context)
+    FilteringClassLoader classLoader = new FilteringClassLoader(getClass().getClassLoader(), context)
     classLoader.addServerClass('ch.qos.logback.')
     classLoader.addServerClass('org.slf4j.')
     classLoader.addServerClass('org.codehaus.groovy.')


### PR DESCRIPTION
Fix for #361 

Default org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern on the webappcontext to the standard jar names so JSTL TLDs are found by default (like they were previously in older jetty versions)