### PR TITLE
Fix incompatibility with java-library plugin

### DIFF
--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/GrettyPlugin.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/GrettyPlugin.groovy
@@ -28,7 +28,7 @@ class GrettyPlugin implements Plugin<Project> {
 
   private void addConfigurations(Project project) {
     project.configurations {
-      compile {
+      implementation {
         exclude module: 'spring-boot-starter-tomcat'
         exclude module: 'spring-boot-starter-jetty'
       }
@@ -49,7 +49,7 @@ class GrettyPlugin implements Plugin<Project> {
       }
       grettyProductRuntime
       grettyProvidedCompile
-      project.configurations.findByName('compile')?.extendsFrom grettyProvidedCompile
+      project.configurations.findByName('implementation')?.extendsFrom grettyProvidedCompile
     }
 
     ServletContainerConfig.getConfigs().each { configName, config ->
@@ -58,7 +58,7 @@ class GrettyPlugin implements Plugin<Project> {
   }
 
   private void addConfigurationsAfterEvaluate(Project project) {
-    def runtimeConfig = project.configurations.findByName('runtime')
+    def runtimeConfig = project.configurations.findByName('runtimeClasspath')
     project.configurations {
       springBoot {
         if (runtimeConfig)
@@ -104,7 +104,7 @@ class GrettyPlugin implements Plugin<Project> {
     }
 
     if(project.gretty.springBoot) {
-      String configName = project.configurations.findByName('compile') ? 'compile' : 'springBoot'
+      String configName = project.configurations.findByName('implementation') ? 'implementation' : 'springBoot'
       project.dependencies.add configName, "org.springframework.boot:spring-boot-starter-web:$springBootVersion", {
         exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
       }
@@ -114,14 +114,14 @@ class GrettyPlugin implements Plugin<Project> {
       project.dependencies.add configName, "org.springframework:spring-messaging:$springVersion"
       project.dependencies.add configName, "org.springframework:spring-websocket:$springVersion"
       project.dependencies.add configName, "ch.qos.logback:logback-classic:$logbackVersion"
-      configName = project.configurations.findByName('runtime') ? 'runtime' : 'springBoot'
+      configName = project.configurations.findByName('runtimeOnly') ? 'runtimeOnly' : 'springBoot'
       project.dependencies.add configName, "org.akhikhl.gretty:gretty-springboot:$grettyVersion"
     }
 
     for(String overlay in project.gretty.overlays)
       project.dependencies.add 'grettyProvidedCompile', project.project(overlay)
 
-    def runtimeConfig = project.configurations.findByName('runtime')
+    def runtimeConfig = project.configurations.findByName('runtimeClasspath')
     if(runtimeConfig) {
       if(runtimeConfig.allDependencies.find { it.name == 'slf4j-api' } && !runtimeConfig.allDependencies.find { it.name in ['slf4j-nop', 'slf4j-simple', 'slf4j-log4j12', 'slf4j-jdk14', 'logback-classic', 'log4j-slf4j-impl'] }) {
         project.dependencies {

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProductConfigurer.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProductConfigurer.groovy
@@ -96,7 +96,7 @@ class ProductConfigurer {
         for(WebAppConfig wconfig in wconfigs) {
           // projects are already set as input in dependsOn
           if(wconfig.projectPath)
-            result.addAll project.project(wconfig.projectPath).configurations.runtime.files
+            result.addAll project.project(wconfig.projectPath).configurations.runtimeClasspath.files
           else
             result.add wconfig.resourceBase
           if(wconfig.realmConfigFile)

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProjectUtils.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/ProjectUtils.groovy
@@ -222,7 +222,7 @@ final class ProjectUtils {
 
   // ATTENTION: this function resolves compile configuration!
   static boolean isSpringBootApp(Project project) {
-    def compileConfig = project.configurations.findByName('compile')
+    def compileConfig = project.configurations.findByName('compileOnly')
     compileConfig && compileConfig.resolvedConfiguration.resolvedArtifacts.find { it.moduleVersion.id.group == 'org.springframework.boot' }
   }
 

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/ServletContainerConfig.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/ServletContainerConfig.groovy
@@ -30,7 +30,7 @@ class ServletContainerConfig {
       if(webXmlFile.exists()) {
         def webXml = new XmlSlurper().parse(webXmlFile)
         if(webXml.filter.find { it.'filter-class'.text() == 'org.akhikhl.gretty.RedirectFilter' }) {
-          project.dependencies.add 'runtime', "org.akhikhl.gretty:gretty-filter:${project.ext.grettyVersion}", {
+          project.dependencies.add 'runtimeOnly', "org.akhikhl.gretty:gretty-filter:${project.ext.grettyVersion}", {
             exclude group: 'javax.servlet', module: 'servlet-api'
           }
           alteredDependencies = true

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/StartBaseTask.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/StartBaseTask.groovy
@@ -207,7 +207,7 @@ abstract class StartBaseTask extends DefaultTask {
             Set<URL> resolvedClassPath = new LinkedHashSet<URL>()
             if(wconfig.projectPath) {
               def proj = self.project.project(wconfig.projectPath)
-              String runtimeConfig = ProjectUtils.isSpringBootApp(proj) ? 'springBoot' : 'runtime'
+              String runtimeConfig = ProjectUtils.isSpringBootApp(proj) ? 'springBoot' : 'runtimeClasspath'
               resolvedClassPath.addAll(ProjectUtils.resolveClassPath(proj, wconfig.beforeClassPath))
               resolvedClassPath.addAll(ProjectUtils.getClassPath(proj, wconfig.inplace, runtimeConfig))
               resolvedClassPath.addAll(ProjectUtils.resolveClassPath(proj, wconfig.classPath))

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/scanner/BaseScannerManager.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/scanner/BaseScannerManager.groovy
@@ -74,7 +74,7 @@ abstract class BaseScannerManager implements ScannerManager {
     }
 
     protected static void collectDependenciesSourceSets(Collection<File> scanDirs, Project p) {
-        List<Project> dependencyProjects = ProjectUtils.getDependencyProjects(p, 'compile')
+        List<Project> dependencyProjects = ProjectUtils.getDependencyProjects(p, 'implementation')
         for(Project project: dependencyProjects) {
             // adding sourceSets of dependecy project
             scanDirs.addAll(project.sourceSets.main.allSource.srcDirs)
@@ -152,7 +152,8 @@ abstract class BaseScannerManager implements ScannerManager {
         for(String f in changedFiles) {
             if(f.endsWith('.jar')) {
                 List<WebAppConfig> dependantWebAppProjects = webapps.findAll {
-                    it.projectPath && project.project(it.projectPath).configurations.compile.resolvedConfiguration.resolvedArtifacts.find { it.file.absolutePath == f }
+                    it.projectPath && project.project(it.projectPath).configurations.implementation.resolvedConfiguration.resolvedArtifacts.find {
+                        it.file.absolutePath == f }
                 }
                 if(dependantWebAppProjects) {
                     for(WebAppConfig wconfig in dependantWebAppProjects) {


### PR DESCRIPTION
This plugin has existed since gradle 3.4 and gradle added the same configurations to the older java library.
However without using the newer configurations the classpath is not configured correctly.
Therefore make use of the new configurations to ensure compatibility