### PR TITLE
Gradle 3 still uses SourceSetObject.getClassesDir instead of SourceSe…

### DIFF
--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/SpringBootMainClassFinder.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/SpringBootMainClassFinder.groovy
@@ -17,7 +17,7 @@ import org.gradle.api.Project
 class SpringBootMainClassFinder {
 
   protected static Iterable<File> getClassesDirs(Project project) {
-    if(project.gradle.gradleVersion.startsWith('1.') || project.gradle.gradleVersion.startsWith('2.'))
+    if(project.gradle.gradleVersion.startsWith('1.') || project.gradle.gradleVersion.startsWith('2.') || project.gradle.gradleVersion.startsWith('3.'))
       return [ project.sourceSets.main.output.classesDir ]
     project.sourceSets.main.output.classesDirs
   }


### PR DESCRIPTION
springboot projects using gradle 3.x and gretty 2.0.0 fail. This uses the correct method for gradle 3.x.