### PR TITLE
resolved issue #392: made the logback version number configurable

### DIFF
--- a/libs/gretty-core/src/main/groovy/org/akhikhl/gretty/ServerConfig.groovy
+++ b/libs/gretty-core/src/main/groovy/org/akhikhl/gretty/ServerConfig.groovy
@@ -70,6 +70,7 @@ class ServerConfig {
   String springBootVersion
   String springLoadedVersion
   String springVersion
+  String logbackVersion
   Boolean singleSignOn
   /**
    * Tomcat-specific: Enables JNDI naming which is disabled by default.

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/GrettyPlugin.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/GrettyPlugin.groovy
@@ -82,7 +82,7 @@ class GrettyPlugin implements Plugin<Project> {
     String springLoadedVersion = project.gretty.springLoadedVersion ?: (project.hasProperty('springLoadedVersion') ? project.springLoadedVersion : Externalized.getString('springLoadedVersion'))
     String springVersion = project.gretty.springVersion ?: (project.hasProperty('springVersion') ? project.springVersion : Externalized.getString('springVersion'))
     String slf4jVersion = Externalized.getString('slf4jVersion')
-    String logbackVersion = Externalized.getString('logbackVersion')
+    String logbackVersion = project.gretty.logbackVersion ?: (project.hasProperty('logbackVersion') ? project.logbackVersion :Externalized.getString('logbackVersion'))
 
     project.dependencies {
       grettyStarter "org.akhikhl.gretty:gretty-starter:$grettyVersion"


### PR DESCRIPTION
through the gretty gradle extension:

```
gretty {
    springBoot = true
    logbackVersion = '1.2.3'
}
```