### PR TITLE
Stop adding org.slf4j:slf4j-nop:1.7.12 to war when slf4j-api is prese…

### DIFF
--- a/libs/gretty-core/build.gradle
+++ b/libs/gretty-core/build.gradle
@@ -32,7 +32,6 @@ tasks.processResources {
     springBootVersion: project.springBootVersion,
     springLoadedVersion: project.springLoadedVersion,
     springVersion: project.springVersion,
-    slf4jVersion: project.slf4j_version,
     logbackVersion: project.logback_version,
     asmVersion: project.asm_version
   ]

--- a/libs/gretty-core/src/main/resources/org/akhikhl/gretty/Externalized.properties
+++ b/libs/gretty-core/src/main/resources/org/akhikhl/gretty/Externalized.properties
@@ -14,6 +14,5 @@ tomcat8ServletApiVersion=@tomcat8ServletApiVersion@
 springBootVersion=@springBootVersion@
 springLoadedVersion=@springLoadedVersion@
 springVersion=@springVersion@
-slf4jVersion=@slf4jVersion@
 logbackVersion=@logbackVersion@
 asmVersion=@asmVersion@

--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/GrettyPlugin.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/GrettyPlugin.groovy
@@ -81,7 +81,6 @@ class GrettyPlugin implements Plugin<Project> {
     String springBootVersion = project.gretty.springBootVersion ?: (project.hasProperty('springBootVersion') ? project.springBootVersion : Externalized.getString('springBootVersion'))
     String springLoadedVersion = project.gretty.springLoadedVersion ?: (project.hasProperty('springLoadedVersion') ? project.springLoadedVersion : Externalized.getString('springLoadedVersion'))
     String springVersion = project.gretty.springVersion ?: (project.hasProperty('springVersion') ? project.springVersion : Externalized.getString('springVersion'))
-    String slf4jVersion = Externalized.getString('slf4jVersion')
     String logbackVersion = Externalized.getString('logbackVersion')
 
     project.dependencies {
@@ -124,9 +123,7 @@ class GrettyPlugin implements Plugin<Project> {
     def runtimeConfig = project.configurations.findByName('runtime')
     if(runtimeConfig) {
       if(runtimeConfig.allDependencies.find { it.name == 'slf4j-api' } && !runtimeConfig.allDependencies.find { it.name in ['slf4j-nop', 'slf4j-simple', 'slf4j-log4j12', 'slf4j-jdk14', 'logback-classic', 'log4j-slf4j-impl'] }) {
-        project.dependencies {
-          compile "org.slf4j:slf4j-nop:$slf4jVersion"
-        }
+        log.warn("Found slf4j-api dependency but no providers were found.  Did you mean to add slf4j-simple? See https://www.slf4j.org/codes.html#noProviders .")
       }
     }
 


### PR DESCRIPTION
…nt but impls are seemingly missing in deps.  Fixed #394.

Instead the build now logs a warning:

> Configure project :
Found slf4j-api dependency but no providers were found.  Did you mean to add slf4j-simple? See https://www.slf4j.org/codes.html#noProviders .