### PR TITLE
Fix compatibility with Gradle 4.6

### DIFF
--- a/libs/gretty/src/main/groovy/org/akhikhl/gretty/StartBaseTask.groovy
+++ b/libs/gretty/src/main/groovy/org/akhikhl/gretty/StartBaseTask.groovy
@@ -152,6 +152,7 @@ abstract class StartBaseTask extends DefaultTask {
           getOutputs: { startTask.getOutputs() },
           getProject: { startTask.project },
           getWorkingDir: { project.projectDir },
+          getJvmArgumentProviders: { [] }
       ]) as JacocoHelper
       project.jacoco.applyTo(jacocoHelper)
       jacocoHelper.jacoco.enabled = getDefaultJacocoEnabled()


### PR DESCRIPTION
Gradle 4.6 introduced a `getJvmArgumentProviders` which it expects to
never return `null`. If `null` is returned, then applying the
`JacocoPluginExtension` fails.