### PR TITLE
Remove the isServletApi checks

### DIFF
--- a/libs/gretty-runner-jetty7/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
+++ b/libs/gretty-runner-jetty7/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
@@ -36,10 +36,6 @@ class JettyConfigurerImpl implements JettyConfigurer {
 
   private static final Logger log = LoggerFactory.getLogger(JettyConfigurerImpl)
 
-  protected static boolean isServletApi(String filePath) {
-    filePath.matches(/^.*servlet-api.*\.jar$/)
-  }
-
   private SSOAuthenticatorFactory ssoAuthenticatorFactory
   private HashSessionManager sharedSessionManager
 
@@ -201,8 +197,8 @@ class JettyConfigurerImpl implements JettyConfigurer {
   def createWebAppContext(Map serverParams, Map webappParams) {
     List<String> webappClassPath = webappParams.webappClassPath
     JettyWebAppContext context = new JettyWebAppContext()
-    context.setWebInfLib(webappClassPath.findAll { it.endsWith('.jar') && !isServletApi(it) }.collect { new File(it) })
-    context.setExtraClasspath(webappClassPath.collect { it.endsWith('.jar') ? it : (it.endsWith('/') ? it : it + '/') }.findAll { !isServletApi(it) }.join(';'))
+    context.setWebInfLib(webappClassPath.findAll { it.endsWith('.jar') }.collect { new File(it) })
+    context.setExtraClasspath(webappClassPath.collect { it.endsWith('.jar') ? it : (it.endsWith('/') ? it : it + '/') }.join(';'))
     if (webappParams.webXml != null) context.setDescriptor(webappParams.webXml);
     FilteringClassLoader classLoader = new FilteringClassLoader(context)
     classLoader.addServerClass('ch.qos.logback.')

--- a/libs/gretty-runner-jetty8/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
+++ b/libs/gretty-runner-jetty8/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
@@ -36,10 +36,6 @@ class JettyConfigurerImpl implements JettyConfigurer {
 
   private static final Logger log = LoggerFactory.getLogger(JettyConfigurerImpl)
 
-  protected static boolean isServletApi(String filePath) {
-    filePath.matches(/^.*servlet-api.*\.jar$/)
-  }
-
   private SSOAuthenticatorFactory ssoAuthenticatorFactory
   private HashSessionManager sharedSessionManager
 
@@ -201,8 +197,8 @@ class JettyConfigurerImpl implements JettyConfigurer {
   def createWebAppContext(Map serverParams, Map webappParams) {
     List<String> webappClassPath = webappParams.webappClassPath
     JettyWebAppContext context = new JettyWebAppContext()
-    context.setWebInfLib(webappClassPath.findAll { it.endsWith('.jar') && !isServletApi(it) }.collect { new File(it) })
-    context.setExtraClasspath(webappClassPath.collect { it.endsWith('.jar') ? it : (it.endsWith('/') ? it : it + '/') }.findAll { !isServletApi(it) }.join(';'))
+    context.setWebInfLib(webappClassPath.findAll { it.endsWith('.jar') }.collect { new File(it) })
+    context.setExtraClasspath(webappClassPath.collect { it.endsWith('.jar') ? it : (it.endsWith('/') ? it : it + '/') }.join(';'))
     if (webappParams.webXml != null) context.setDescriptor(webappParams.webXml);
     FilteringClassLoader classLoader = new FilteringClassLoader(context)
     classLoader.addServerClass('ch.qos.logback.')

--- a/libs/gretty-runner-jetty9/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
+++ b/libs/gretty-runner-jetty9/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
@@ -33,10 +33,6 @@ class JettyConfigurerImpl implements JettyConfigurer {
 
   private static final Logger log = LoggerFactory.getLogger(JettyConfigurerImpl)
 
-  protected static boolean isServletApi(String filePath) {
-    filePath.matches(/^.*servlet-api.*\.jar$/)
-  }
-
   private SSOAuthenticatorFactory ssoAuthenticatorFactory
   private HashSessionManager sharedSessionManager
 
@@ -207,8 +203,8 @@ class JettyConfigurerImpl implements JettyConfigurer {
     String webappClasspathScanPattern = webappParams.webInfIncludeJarPattern
     JettyWebAppContext context = new JettyWebAppContext()
     context.setAttribute("org.eclipse.jetty.server.webapp.WebInfIncludeJarPattern", webappClasspathScanPattern)
-    context.setWebInfLib(webappClassPath.findAll { it.endsWith('.jar') && !isServletApi(it) }.collect { new File(it) })
-    context.setExtraClasspath(webappClassPath.collect { it.endsWith('.jar') ? it : (it.endsWith('/') ? it : it + '/') }.findAll { !isServletApi(it) }.join(';'))
+    context.setWebInfLib(webappClassPath.findAll { it.endsWith('.jar') }.collect { new File(it) })
+    context.setExtraClasspath(webappClassPath.collect { it.endsWith('.jar') ? it : (it.endsWith('/') ? it : it + '/') }.join(';'))
     context.setInitParameter('org.eclipse.jetty.servlet.Default.useFileMappedBuffer', serverParams.productMode ? 'true' : 'false')
     if (webappParams.webXml != null) context.setDescriptor(webappParams.webXml);
     FilteringClassLoader classLoader = new FilteringClassLoader(context)

--- a/libs/gretty-runner-jetty93/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
+++ b/libs/gretty-runner-jetty93/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
@@ -33,10 +33,6 @@ class JettyConfigurerImpl implements JettyConfigurer {
 
   private static final Logger log = LoggerFactory.getLogger(JettyConfigurerImpl)
 
-  protected static boolean isServletApi(String filePath) {
-    filePath.matches(/^.*servlet-api.*\.jar$/)
-  }
-
   private SSOAuthenticatorFactory ssoAuthenticatorFactory
   private HashSessionManager sharedSessionManager
 
@@ -205,8 +201,8 @@ class JettyConfigurerImpl implements JettyConfigurer {
   def createWebAppContext(Map serverParams, Map webappParams) {
     List<String> webappClassPath = webappParams.webappClassPath
     JettyWebAppContext context = new JettyWebAppContext()
-    context.setWebInfLib(webappClassPath.findAll { it.endsWith('.jar') && !isServletApi(it) }.collect { new File(it) })
-    context.setExtraClasspath(webappClassPath.collect { it.endsWith('.jar') ? it : (it.endsWith('/') ? it : it + '/') }.findAll { !isServletApi(it) }.join(';'))
+    context.setWebInfLib(webappClassPath.findAll { it.endsWith('.jar') }.collect { new File(it) })
+    context.setExtraClasspath(webappClassPath.collect { it.endsWith('.jar') ? it : (it.endsWith('/') ? it : it + '/') }.join(';'))
     context.setInitParameter('org.eclipse.jetty.servlet.Default.useFileMappedBuffer', serverParams.productMode ? 'true' : 'false')
     context.setAttribute('org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern',
             '.*/[^/]*servlet-api-[^/]*\\.jar$|.*/javax.servlet.jsp.jstl-.*\\.jar$|.*/[^/]*taglibs.*\\.jar$');

--- a/libs/gretty-runner-jetty94/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
+++ b/libs/gretty-runner-jetty94/src/main/groovy/org/akhikhl/gretty/JettyConfigurerImpl.groovy
@@ -32,10 +32,6 @@ class JettyConfigurerImpl implements JettyConfigurer {
 
   private static final Logger log = LoggerFactory.getLogger(JettyConfigurerImpl)
 
-  protected static boolean isServletApi(String filePath) {
-    filePath.matches(/^.*servlet-api.*\.jar$/)
-  }
-
   private SSOAuthenticatorFactory ssoAuthenticatorFactory
   private SessionHandler sharedSessionHandler
 
@@ -204,8 +200,8 @@ class JettyConfigurerImpl implements JettyConfigurer {
   def createWebAppContext(Map serverParams, Map webappParams) {
     List<String> webappClassPath = webappParams.webappClassPath
     JettyWebAppContext context = new JettyWebAppContext()
-    context.setWebInfLib(webappClassPath.findAll { it.endsWith('.jar') && !isServletApi(it) }.collect { new File(it) })
-    context.setExtraClasspath(webappClassPath.collect { it.endsWith('.jar') ? it : (it.endsWith('/') ? it : it + '/') }.findAll { !isServletApi(it) }.join(';'))
+    context.setWebInfLib(webappClassPath.findAll { it.endsWith('.jar') }.collect { new File(it) })
+    context.setExtraClasspath(webappClassPath.collect { it.endsWith('.jar') ? it : (it.endsWith('/') ? it : it + '/') }.join(';'))
     context.setInitParameter('org.eclipse.jetty.servlet.Default.useFileMappedBuffer', serverParams.productMode ? 'true' : 'false')
     context.setAttribute('org.eclipse.jetty.server.webapp.ContainerIncludeJarPattern',
         '.*/[^/]*servlet-api-[^/]*\\.jar$|.*/javax.servlet.jsp.jstl-.*\\.jar$|.*/[^/]*taglibs.*\\.jar$');

--- a/libs/gretty-runner-tomcat8/src/main/groovy/org/akhikhl/gretty/TomcatConfigurerImpl.groovy
+++ b/libs/gretty-runner-tomcat8/src/main/groovy/org/akhikhl/gretty/TomcatConfigurerImpl.groovy
@@ -24,10 +24,6 @@ class TomcatConfigurerImpl implements TomcatConfigurer {
 
   private static final Logger log = LoggerFactory.getLogger(TomcatConfigurerImpl)
 
-  protected static boolean isServletApi(String filePath) {
-    filePath.matches(/^.*servlet-api.*\.jar$/)
-  }
-
   @Override
   ContextConfig createContextConfig(URL[] classpathUrls) {
 
@@ -75,7 +71,7 @@ class TomcatConfigurerImpl implements TomcatConfigurer {
     if (webappParams.webXml)
       context.setAltDDName(webappParams.webXml);
 
-    Set classpathJarParentDirs = webappParams.webappClassPath.findAll { it.endsWith('.jar') && !isServletApi(it) }.collect({
+    Set classpathJarParentDirs = webappParams.webappClassPath.findAll { it.endsWith('.jar') }.collect({
       File jarFile = it.startsWith('file:') ? new File(new URI(it)) : new File(it)
       jarFile
     }) as Set


### PR DESCRIPTION
Fix for #418 

Removes the `isServletApi()` checks from all of the `JettyConfigurers` and `TomcatConfigurers`.  They were improperly filtering users' jars that had "servlet-api" in the name.